### PR TITLE
fix: lock down `semantic-release` peer dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bin": "./bin/semantic-release-github-pr.js",
   "license": "MIT",
   "peerDependencies": {
-    "semantic-release": "12.2.5 - 13"
+    "semantic-release": "12.2.5 - 13.2.0"
   },
   "dependencies": {
     "execa": "^0.8.0",


### PR DESCRIPTION
Due to reliance on `semantic-release` internals, its version 13.3.0 breaks our current implementation.