### PR TITLE
fix: only publish the source to `npm`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": " A `semantic-release` plugin that creates a changelog comment on Github PRs.",
   "main": "src/index.js",
+  "files": ["src"],
   "repository": "https://github.com/Updater/semantic-release-github-pr.git",
   "scripts": {
     "format": "prettier --write --single-quote --trailing-comma es5",


### PR DESCRIPTION
Keeps from publishing `yarn.lock` (possibly preventing consumers from getting latest versions of `dependencies`?).