### PR TITLE
fix: this major version not compat w/ `semantic-release` >= 15.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bin": "./bin/semantic-release-github-pr.js",
   "license": "MIT",
   "peerDependencies": {
-    "semantic-release": "13.4.1 - 15.x.x"
+    "semantic-release": "13.4.1 - 15.6.x"
   },
   "dependencies": {
     "execa": "^0.8.0",


### PR DESCRIPTION
As of `semantic-release` 15.7.0, `generateNotes` is now allowed to be multiple plugins, breaking the how this plugin wraps `generateNotes`.

https://github.com/semantic-release/semantic-release/releases/tag/v15.7.0