### PR TITLE
fix: url parsing for GitHub Enterprise

### DIFF
--- a/src/github-init.js
+++ b/src/github-init.js
@@ -1,5 +1,6 @@
 const resolveConfig = require('@semantic-release/github/lib/resolve-config');
 const GitHubApi = require('github');
+const { parse } = require('url');
 
 /**
  * Implementation lifted from `semantic-release`'s default Github plugin:


### PR DESCRIPTION
- The parse symbol is not defined when a GitHub url is provided.